### PR TITLE
Add linux build tag to plugin sources

### DIFF
--- a/cgroups/cgroups.go
+++ b/cgroups/cgroups.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/cgroups/cgroups_test.go
+++ b/cgroups/cgroups_test.go
@@ -1,4 +1,4 @@
-// +build unit
+// +build linux,unit
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/cgroups/metrics.go
+++ b/cgroups/metrics.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package cgroups
 
 type metric struct {

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (


### PR DESCRIPTION
Fixes #3 

After this PR, attempt to build this plugin on other OS than linux will return error message. For example, `GOOS=darwin make` will return:

```
Building Snap Plugin: snap-plugin-collector-cgroups
can't load package: package github.com/intelsdi-x/snap-plugin-collector-cgroups: no buildable Go source
files
```